### PR TITLE
[SECTION-019] layoutsディレクトリによるレイアウトの共通化

### DIFF
--- a/components/AppNavigation.vue
+++ b/components/AppNavigation.vue
@@ -1,0 +1,10 @@
+<template>
+  <ul>
+    <li>
+      <nuxt-link to="/">home</nuxt-link>
+    </li>
+    <li>
+      <nuxt-link to="/child">child</nuxt-link>
+    </li>
+  </ul>
+</template>

--- a/layouts/single.vue
+++ b/layouts/single.vue
@@ -1,9 +1,10 @@
 <template>
   <div>
-    <span>default layout</span>
+    <span>single layout</span>
     <AppNavigation />
     <hr>
-    <nuxt/>
+    <nuxt />
+    <nuxt-link to="/">トップへ戻る</nuxt-link>
     <hr>
     <footer>
       footer

--- a/pages/child.vue
+++ b/pages/child.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Child</h1>
+  </div>
+</template>
+<script>
+  export default {
+    layout: 'single'
+  }
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,25 +1,5 @@
 <template>
-  <section class="container">
-    <div>
-      <app-logo/>
-      <h1 class="title">
-        my-first-nuxt-app-chapter03
-      </h1>
-      <h2 class="subtitle">
-        Nuxt.js project
-      </h2>
-      <div class="links">
-        <a
-          href="https://nuxtjs.org/"
-          target="_blank"
-          class="button--green">Documentation</a>
-        <a
-          href="https://github.com/nuxt/nuxt.js"
-          target="_blank"
-          class="button--grey">GitHub</a>
-      </div>
-    </div>
-  </section>
+  <h1>Index page</h1>
 </template>
 
 <script>


### PR DESCRIPTION
Nuxt.jsのレイアウトについて学んだ。本PRはSECTION-019の変更内容です。

### SECTION-019 お勉強メモ

- Nuxt.jsはデフォルトのレイアウトとして、default.vueを所持していて、特にレイアウト指定がない場合は、default.vueが参照される仕様

- Nuxt.jsではアプリケーション全t内は持ちラン、カテゴリ分けしてそれぞれのページ特徴に合わせたテンプレートの切り替えが可能（例えば、特定のページにのみ、特定のレイアウトを適用させるということが可能）

- このPRの例だと、テンプレート `layouts/single.vue`を作成して、これを `pages/child.vue` で適用させてる。適用する際は、以下のような感じで書いて反映させる

```
<script>
  export default {
    layout: 'single'
  }
</script>
```

