### PR TITLE
[SECTION-021] middlewareによるグローバルなフックの登録

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,18 @@
-export default () => {
-  if (process.browser){
-    console.log('console.log() on browser')
-  } else {
-    console.log('console.log() on SSR server')
+import Cookies from 'universal-cookie'
+
+export default ({req, route, redirect}) => {
+  console.log(route.path)
+
+  if (['/'].includes(route.path)) {
+    return
+  }
+  const cookies = req ? new Cookies(req.headers.cookie) : new Cookies()
+  const credential = cookies.get('credential')
+
+  if (credential && route.path === '/login') {
+    return redirect('/')
+  }
+  if (!credential && route.path !== '/login') {
+    return redirect('/login')
   }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,7 @@
+export default () => {
+  if (process.browser){
+    console.log('console.log() on browser')
+  } else {
+    console.log('console.log() on SSR server')
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  router: {
+    middleware: [
+      'auth'
+    ]
+  },
   /*
   ** Headers of the page
   */

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
-    "nuxt": "^2.0.0"
+    "nuxt": "^2.0.0",
+    "universal-cookie": "^4.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/pages/authed-route.vue
+++ b/pages/authed-route.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <h2>認証が必要なページ</h2>
+    <p>
+      Cookieの 'credential' 値が Truethyな場合のみアクセス可能です <br>
+      <nuxt-link to="/">トップページへ戻る</nuxt-link>
+    </p>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,45 +1,13 @@
 <template>
-  <h1>Index page</h1>
+  <div>
+    <h2>index page</h2>
+    <ul>
+      <li>
+        <nuxt-link to="/login">ログインページへ</nuxt-link>
+      </li>
+      <li>
+        <nuxt-link to="/authed-route">認証が必要なページへ</nuxt-link>
+      </li>
+    </ul>
+  </div>
 </template>
-
-<script>
-import AppLogo from '~/components/AppLogo.vue'
-
-export default {
-  components: {
-    AppLogo
-  }
-}
-</script>
-
-<style>
-.container {
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
-
-.title {
-  font-family: "Quicksand", "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; /* 1 */
-  display: block;
-  font-weight: 300;
-  font-size: 100px;
-  color: #35495e;
-  letter-spacing: 1px;
-}
-
-.subtitle {
-  font-weight: 300;
-  font-size: 42px;
-  color: #526488;
-  word-spacing: 5px;
-  padding-bottom: 15px;
-}
-
-.links {
-  padding-top: 15px;
-}
-</style>
-

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <h2>ログインページ</h2>
+    <p>
+      <button type="button" @click="login">ログイン</button>
+      <nuxt-link to="/">トップページへ戻る</nuxt-link>
+    </p>
+  </div>
+</template>
+
+<script>
+  import Cookies from 'universal-cookie'
+  export default {
+    methods: {
+      login() {
+        const cookies = new Cookies()
+        cookies.set('credential', 'true', { maxAge: 90})
+        this.$router.push('/')
+      }
+    }
+  }
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,11 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/debug@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.4.tgz#56eec47706f0fd0b7c694eae2f3172e6b0b769da"
@@ -1003,6 +1008,11 @@
   version "8.10.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.50.tgz#f3d68482b1f54b5f4fba8daaac385db12bb6a706"
   integrity sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA==
+
+"@types/object-assign@^4.0.30":
+  version "4.0.30"
+  resolved "https://registry.yarnpkg.com/@types/object-assign/-/object-assign-4.0.30.tgz#8949371d5a99f4381ee0f1df0a9b7a187e07e652"
+  integrity sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -2372,7 +2382,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -8118,6 +8128,16 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+universal-cookie@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.2.tgz#c3398a64c72ff0c31fecb1ac4966c424e8669c6d"
+  integrity sha512-n14lhA//lQeYRweP9j9uXsshN9Cs4LunVSnvAGmnA69SofwsjpUU03geaCaPC9LlsH2rkBy99o3zxQyVOldGvA==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    "@types/object-assign" "^4.0.30"
+    cookie "^0.4.0"
+    object-assign "^4.1.1"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
### 変更内容

- Nuxt.jsのミドルウェアの機能を利用して、認証の処理を実装した
- 認証の処理は、ログインする際に、Cookieにcredentialをセットして、以降はcredentialがセットされてるかどうか確認するという簡易的なもの

### お勉強メモ
#### ミドルウェアとは
- 任意のルーティングのアクセス時に最初に読み込まれる
- SSR処理などが行われる前に実施される
- ユーザーエージェントに合わせたリダイレクトができる
- 認証認可の必要なページの構築の際はミドルウェアを使う
- 今回のサンプルコードの `middleware/auth.js` の ` export default ({req, route, redirect}) => { ` あたりの処理について。
  - ミドルウェア関数には、contextと呼ばれるオブジェクトが引数として渡される
  - contextオブジェクトは非常に多くのデータを保持してる（詳細はドキュメントを参考 https://ja.nuxtjs.org/api/context/）
  - この処理では、contextからリクエストとVue Routerのrouteオブジェクトとリダイレクトのための関数を受け取ってる

- ミドルウェアの登録について。nuxt.js.configにこんな感じで記述する？
```
  router: {
    middleware: [
      'auth'
    ]
  },
```